### PR TITLE
Repository dispatch

### DIFF
--- a/actions/handlers.go
+++ b/actions/handlers.go
@@ -10,10 +10,11 @@ import (
 )
 
 type Handlers struct {
-	IssueComment     func(context.Context, *github.IssueCommentEvent) error
-	PullRequest      func(context.Context, *github.PullRequestEvent) error
-	Schedule         func(context.Context) error
-	WorkflowDispatch func(context.Context) error
+	IssueComment       func(context.Context, *github.IssueCommentEvent) error
+	PullRequest        func(context.Context, *github.PullRequestEvent) error
+	RepositoryDispatch func(context.Context, *github.RepositoryDispatchEvent) error
+	Schedule           func(context.Context) error
+	WorkflowDispatch   func(context.Context) error
 }
 
 // Handle invokes the appropriate handler for an given actions Environment.
@@ -70,6 +71,14 @@ func (h *Handlers) handler(event string) func(context.Context, interface{}) erro
 		}
 		return func(ctx context.Context, evt interface{}) error {
 			return h.PullRequest(ctx, evt.(*github.PullRequestEvent))
+		}
+
+	case "repository_dispatch":
+		if h.RepositoryDispatch == nil {
+			return nil
+		}
+		return func(ctx context.Context, evt interface{}) error {
+			return h.RepositoryDispatch(ctx, evt.(*github.RepositoryDispatchEvent))
 		}
 
 	case "schedule":

--- a/actions/updateaction/handlers.go
+++ b/actions/updateaction/handlers.go
@@ -1,7 +1,10 @@
 package updateaction
 
 import (
+	"context"
+
 	"github.com/go-git/go-git/v5"
+	"github.com/google/go-github/v32/github"
 	"github.com/thepwagner/action-update/actions"
 	gitrepo "github.com/thepwagner/action-update/repo"
 	"github.com/thepwagner/action-update/updater"
@@ -16,9 +19,12 @@ type HandlerParams interface {
 func NewHandlers(p HandlerParams) *actions.Handlers {
 	h := &handler{cfg: p.env(), updaterFactory: p}
 	return &actions.Handlers{
-		IssueComment:     IssueComment,
-		PullRequest:      h.PullRequest,
-		Schedule:         h.UpdateAll,
+		IssueComment: IssueComment,
+		PullRequest:  h.PullRequest,
+		Schedule:     h.UpdateAll,
+		RepositoryDispatch: func(ctx context.Context, _ *github.RepositoryDispatchEvent) error {
+			return h.UpdateAll(ctx)
+		},
 		WorkflowDispatch: h.UpdateAll,
 	}
 }


### PR DESCRIPTION
I'm about to make a release, then go click the `workflow_dispatch` button in several downstream dependencies. There's _got_ to be a better way.

By reacting to `repository_dispatch`, I can signal downstream repositories that they should consume the release that was just published. I don't mind maintaining the mapping manually.
