### PR TITLE
send repository_dispatch on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,13 @@
+name: Release
+on:
+  release:
+    types: [released]
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: script/release
+        env:
+          GITHUB_TOKEN: ${{ secrets.MY_GITHUB_PAT }}

--- a/script/release
+++ b/script/release
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# This script triggers "repository_dispatch" events on an array of dependencies
+# https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#repository_dispatch
+# It's expected these events will be handled by an action-update-go workflow, to open a PR updating the just-released dependency
+
+DOWNSTREAMS=(
+  thepwagner/action-update-go
+  thepwagner/action-update-docker
+  thepwagner/action-update-dockerurl
+)
+
+REPO_NAME=$(jq '.repository.full_name' "$GITHUB_EVENT_PATH")
+TAG_NAME=$(jq '.release.tag_name' "$GITHUB_EVENT_PATH")
+EMPTY_PAYLOAD='{"event_type":"action-update-go-release","client_payload":{"path":"","version":""}}'
+
+EVENT_PAYLOAD=$(echo "$EMPTY_PAYLOAD" | jq ".client_payload.path = github.com/$REPO_NAME" | jq ".client_payload.version = $TAG_NAME")
+AUTH_HEADER="Authorization: token $GITHUB_TOKEN"
+for DS in "${DOWNSTREAMS[@]}"; do
+  echo "$DS"
+  curl -H "$AUTH_HEADER" \
+    -d "$EVENT_PAYLOAD" \
+    "https://api.github.com/repos/${DS}/dispatches"
+done
+


### PR DESCRIPTION
Following from #4 , hopefully `v0.0.3` will be the last release that doesn't get magically PR'ed like this.

There's an exciting extension here for evaluating pre-releases... braindumping on that:
* Open an issue on _this_ repository
* Pass the issue URL to consumers
* Have consumers include the issue URL in PR description, causing GitHub to link

That's a cool demo, right?

I don't think we can do better: the checkruns we care about are for the downstream project's CI. Since those are triggered by Actions, it's impossible for an Actions-based hook like `action-update` can offer to capture feedback.
Maybe _this_ action could block, polling downstream checks to evaluate results?