### PR TITLE
Implement cooldowns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,7 +23,6 @@ linters:
     - dupl
     - errcheck
     - exhaustive
-    - funlen
     - goconst
     - gocritic
     - gocyclo
@@ -54,7 +53,3 @@ issues:
   exclude:
     - G101
     - G306
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - funlen

--- a/repo/git.go
+++ b/repo/git.go
@@ -282,3 +282,7 @@ func (t *GitRepo) push(ctx context.Context) error {
 	logrus.Debug("pushed to remote")
 	return nil
 }
+
+func (t *GitRepo) ExistingUpdates(context.Context, string) (updater.ExistingUpdates, error) {
+	return nil, nil
+}

--- a/repo/github.go
+++ b/repo/github.go
@@ -105,11 +105,11 @@ func (g *GitHubRepo) createPR(ctx context.Context, updates updater.UpdateGroup) 
 	return nil
 }
 
-func (g *GitHubRepo) ExistingUpdates(ctx context.Context, baseBranch string) ([]updater.ExistingUpdate, error) {
+func (g *GitHubRepo) ExistingUpdates(ctx context.Context, baseBranch string) (updater.ExistingUpdates, error) {
 	return g.updateFromPR(ctx, baseBranch)
 }
 
-func (g *GitHubRepo) updateFromPR(ctx context.Context, baseBranch string) ([]updater.ExistingUpdate, error) {
+func (g *GitHubRepo) updateFromPR(ctx context.Context, baseBranch string) (updater.ExistingUpdates, error) {
 	// List pull requests targeting this branch:
 	prs, _, err := g.github.PullRequests.List(ctx, g.owner, g.repoName, &github.PullRequestListOptions{
 		State: "all",

--- a/updater/mockrepo_test.go
+++ b/updater/mockrepo_test.go
@@ -28,6 +28,29 @@ func (_m *mockRepo) Branch() string {
 	return r0
 }
 
+// ExistingUpdates provides a mock function with given fields: ctx, baseBranch
+func (_m *mockRepo) ExistingUpdates(ctx context.Context, baseBranch string) (updater.ExistingUpdates, error) {
+	ret := _m.Called(ctx, baseBranch)
+
+	var r0 updater.ExistingUpdates
+	if rf, ok := ret.Get(0).(func(context.Context, string) updater.ExistingUpdates); ok {
+		r0 = rf(ctx, baseBranch)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(updater.ExistingUpdates)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, baseBranch)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Fetch provides a mock function with given fields: ctx, branch
 func (_m *mockRepo) Fetch(ctx context.Context, branch string) error {
 	ret := _m.Called(ctx, branch)

--- a/updater/update.go
+++ b/updater/update.go
@@ -31,3 +31,17 @@ type ExistingUpdate struct {
 	LastUpdate time.Time
 	Group      UpdateGroup
 }
+
+type ExistingUpdates []ExistingUpdate
+
+func (e ExistingUpdates) LatestGroupUpdate(group string) (latest time.Time) {
+	for _, u := range e {
+		if u.Group.Name != group {
+			continue
+		}
+		if u.LastUpdate.After(latest) {
+			latest = u.LastUpdate
+		}
+	}
+	return
+}


### PR DESCRIPTION
Finally implementing the vaporware from https://github.com/thepwagner/action-update/pull/2 !

Adds `Repo.ExistingUpdates()` to query the recent update history from the repository by querying for signed PRs. This replaces a v0 path that parsed branch names - full circle.

Teach `RepoUpdater` to apply `updater.Group.CoolDown` when checking each update group, and ignore groups within their cooldown.


This is the dream. Check every night for _most_ dependencies, but https://github.com/aws/aws-sdk-go/tags only appears weekly.
