### PR TITLE
path ignores

### DIFF
--- a/actions/env.go
+++ b/actions/env.go
@@ -3,7 +3,9 @@ package actions
 import (
 	"fmt"
 	"io/ioutil"
+	"strings"
 
+	"github.com/bmatcuk/doublestar/v2"
 	"github.com/google/go-github/v32/github"
 	"github.com/sirupsen/logrus"
 )
@@ -16,6 +18,7 @@ type Environment struct {
 	GitHubRepository string `env:"GITHUB_REPOSITORY"`
 
 	InputLogLevel string `env:"INPUT_LOG_LEVEL" envDefault:"info"`
+	InputIgnore   string `env:"INPUT_IGNORE"`
 }
 
 // ParseEvent returns deserialized GitHub webhook payload, or an error.
@@ -50,6 +53,16 @@ func (e *Environment) LogLevel() logrus.Level {
 		lvl = logrus.InfoLevel
 	}
 	return lvl
+}
+
+func (e *Environment) Ignored(path string) bool {
+	for _, p := range strings.Split(e.InputIgnore, "\n") {
+		p = strings.TrimSpace(p)
+		if m, _ := doublestar.Match(p, path); m {
+			return true
+		}
+	}
+	return false
 }
 
 // ActionEnvironment smuggles *Environment out of structs that embed one.

--- a/actions/env_test.go
+++ b/actions/env_test.go
@@ -56,3 +56,39 @@ func testIssueComment(t *testing.T, body string) string {
 	require.NoError(t, err)
 	return eventPath
 }
+
+func TestEnvironment_Ignored(t *testing.T) {
+	cases := []struct {
+		ignore     string
+		ignored    []string
+		notIgnored []string
+	}{
+		{
+			ignore:     "foo/*",
+			ignored:    []string{"foo/bar"},
+			notIgnored: []string{"foo", "foo/bar/bar", "bar/foo", "bar/foo/bar"},
+		},
+		{
+			ignore:     "foo/*\nbar/**",
+			ignored:    []string{"foo/bar", "bar/foo", "bar/foo/bar"},
+			notIgnored: []string{"bar", "foo/bar/bar"},
+		},
+		{
+			ignore:     "foo/**/*.bar",
+			ignored:    []string{"foo/a.bar", "foo/bar/b.bar"},
+			notIgnored: []string{"a.bar", "foo/bar", "bar/foo", "bar/foo/bar", "bar", "foo/bar/bar"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.ignore, func(t *testing.T) {
+			e := actions.Environment{InputIgnore: tc.ignore}
+			for _, i := range tc.ignored {
+				assert.True(t, e.Ignored(i))
+			}
+			for _, i := range tc.notIgnored {
+				assert.False(t, e.Ignored(i))
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/thepwagner/action-update
 
 require (
+	github.com/bmatcuk/doublestar/v2 v2.0.1
 	github.com/caarlos0/env/v6 v6.3.0
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/google/go-github/v32 v32.1.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/bmatcuk/doublestar/v2 v2.0.1 h1:EFT91DmIMRcrUEcYUW7AqSAwKvNzP5+CoDmNVBbcQOU=
+github.com/bmatcuk/doublestar/v2 v2.0.1/go.mod h1:QMmcs3H2AUQICWhfzLXz+IYln8lRQmTZRptLie8RgRw=
 github.com/caarlos0/env/v6 v6.3.0 h1:PaqGnS5iHScZ5SnZNBPvQbA2VE/eMAwlp51mKGuEZLg=
 github.com/caarlos0/env/v6 v6.3.0/go.mod h1:nXKfztzgWXH0C5Adnp+gb+vXHmMjKdBnMrSVSczSkiw=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
Adds support for a new input: `ignore`, and the ability to filter paths against it.

This is for places that walk `Dockerfile`s to evaluate updates: `vendor/**` and `**/testdata/**` are usually not worth including.