### PR TITLE
Update github.com/google/go-github/v32 from v32.1.0 to v33.0.0

### DIFF
--- a/actions/env.go
+++ b/actions/env.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/actions/env_test.go
+++ b/actions/env_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/actions/handlers.go
+++ b/actions/handlers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	parser "github.com/caarlos0/env/v6"
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/actions/handlers_test.go
+++ b/actions/handlers_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thepwagner/action-update/actions"

--- a/actions/updateaction/issuecomment.go
+++ b/actions/updateaction/issuecomment.go
@@ -3,7 +3,7 @@ package updateaction
 import (
 	"context"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/actions/updateaction/pullrequest.go
+++ b/actions/updateaction/pullrequest.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/repo"
 	"github.com/thepwagner/action-update/updater"

--- a/actions/updateaction/pullrequest_test.go
+++ b/actions/updateaction/pullrequest_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/thepwagner/action-update/actions/updateaction"
 )

--- a/actions/updateaction/release.go
+++ b/actions/updateaction/release.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/repo"
 )

--- a/actions/updateaction/repositorydispatch.go
+++ b/actions/updateaction/repositorydispatch.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/repo"
 	"github.com/thepwagner/action-update/updater"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/bmatcuk/doublestar/v2 v2.0.4
 	github.com/caarlos0/env/v6 v6.4.0
 	github.com/go-git/go-git/v5 v5.2.0
-	github.com/google/go-github/v32 v32.1.0
+	github.com/google/go-github/v33 v33.0.0
 	github.com/otiai10/copy v1.2.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
-github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
+github.com/google/go-github/v33 v33.0.0 h1:qAf9yP0qc54ufQxzwv+u9H0tiVOnPJxo0lI/JXqw3ZM=
+github.com/google/go-github/v33 v33.0.0/go.mod h1:GMdDnVZY/2TsWgp/lkYnpSAh6TrzhANBBwm6k6TTEXg=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=

--- a/repo/github.go
+++ b/repo/github.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/updater"
 	"golang.org/x/oauth2"

--- a/repo/pullrequest.go
+++ b/repo/pullrequest.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v32/github"
+	"github.com/google/go-github/v33/github"
 	"github.com/thepwagner/action-update/updater"
 )
 


### PR DESCRIPTION
Here is github.com/google/go-github/v32 v33.0.0, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/google/go-github/v32","previous":"v32.1.0","next":"v33.0.0"}]},"signature":"C/gziVz9X3NOJGI1GMV7Pj0FwC7f5zQEoEP8+qfakLdFd+6eUw5Lok9k5P5V6gcMrMGVsF2GSz2CH1VCJ1OHTQ=="}
-->