### PR TITLE
Update github.com/otiai10/copy from v1.3.0 to v1.4.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/caarlos0/env/v6 v6.4.0
 	github.com/go-git/go-git/v5 v5.2.0
 	github.com/google/go-github/v33 v33.0.0
-	github.com/otiai10/copy v1.3.0
+	github.com/otiai10/copy v1.4.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/mod v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/otiai10/copy v1.3.0 h1:Z0OIFgj8hyI18YVzgPXpp652vv0NggCGWaNKSPN9KU8=
-github.com/otiai10/copy v1.3.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
+github.com/otiai10/copy v1.4.0 h1:S9XdWuTRJ54QDIrdbPEVl/1lMwF5xOjd5AvF9S866y8=
+github.com/otiai10/copy v1.4.0/go.mod h1:XWfuS3CrI0R6IE0FbgHsEazaXO8G0LpMp9o8tos0x4E=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/curr v1.0.0 h1:TJIWdbX0B+kpNagQrjgq8bCMrbhiuX73M2XwgtDMoOI=
 github.com/otiai10/curr v1.0.0/go.mod h1:LskTG5wDwr8Rs+nNQ+1LlxRjAtTZZjtJW4rMXl6j4vs=


### PR DESCRIPTION
Here is github.com/otiai10/copy v1.4.0, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/otiai10/copy","previous":"v1.3.0","next":"v1.4.0"}]},"signature":"UzC2boWj+WAlYySdqbx7pOdBQON6a4MtJSOd2kup9LdliuA5g6F3atwvrM9Ef34Y2FrKMtUnVg6Ak4n49wuuAQ=="}
-->