### PR TITLE
Updater.Name()

### DIFF
--- a/actions/updateaction/release_test.go
+++ b/actions/updateaction/release_test.go
@@ -1,0 +1,26 @@
+package updateaction_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-github/v33/github"
+	"github.com/stretchr/testify/require"
+	"github.com/thepwagner/action-update/actions/updateaction"
+)
+
+func TestHandler_Release_WrongAction(t *testing.T) {
+	handlers := updateaction.NewHandlers(&testEnvironment{})
+	err := handlers.Release(context.Background(), &github.ReleaseEvent{
+		Action: github.String("prereleased"),
+	})
+	require.NoError(t, err)
+}
+
+func TestHandler_Release_NoRepos(t *testing.T) {
+	handlers := updateaction.NewHandlers(&testEnvironment{})
+	err := handlers.Release(context.Background(), &github.ReleaseEvent{
+		Action: github.String("released"),
+	})
+	require.NoError(t, err)
+}

--- a/actions/updateaction/repositorydispatch.go
+++ b/actions/updateaction/repositorydispatch.go
@@ -88,6 +88,10 @@ func (h *handler) repoDispatchActionUpdate(ctx context.Context, evt *github.Repo
 	if err != nil {
 		return fmt.Errorf("getting RepoUpdater: %w", err)
 	}
+	if payload.Updater != "" && repoUpdater.Updater.Name() != payload.Updater {
+		logrus.WithField("updater", payload.Updater).Info("skipping event for other updaters")
+		return nil
+	}
 
 	ug := updater.NewUpdateGroup("", update)
 	if err := repoUpdater.Update(ctx, baseBranch, branchName, ug); err != nil {
@@ -98,6 +102,7 @@ func (h *handler) repoDispatchActionUpdate(ctx context.Context, evt *github.Repo
 }
 
 type RepoDispatchActionUpdatePayload struct {
+	Updater  string                                  `json:"updater"`
 	Path     string                                  `json:"path"`
 	Next     string                                  `json:"next"`
 	Feedback RepoDispatchActionUpdatePayloadFeedback `json:"feedback"`

--- a/updater/mockupdater_test.go
+++ b/updater/mockupdater_test.go
@@ -73,3 +73,17 @@ func (_m *mockUpdater) Dependencies(_a0 context.Context) ([]updater.Dependency, 
 
 	return r0, r1
 }
+
+// Name provides a mock function with given fields:
+func (_m *mockUpdater) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -13,7 +13,7 @@ import (
 // RepoUpdater creates branches proposing all available updates for a Go module.
 type RepoUpdater struct {
 	repo        Repo
-	updater     Updater
+	Updater     Updater
 	groups      Groups
 	branchNamer UpdateBranchNamer
 }
@@ -54,7 +54,7 @@ type Factory interface {
 func NewRepoUpdater(repo Repo, updater Updater, opts ...RepoUpdaterOpt) *RepoUpdater {
 	u := &RepoUpdater{
 		repo:        repo,
-		updater:     updater,
+		Updater:     updater,
 		branchNamer: DefaultUpdateBranchNamer{},
 	}
 	for _, opt := range opts {
@@ -83,7 +83,7 @@ func (u *RepoUpdater) Update(ctx context.Context, baseBranch, branchName string,
 		return fmt.Errorf("switching to target branch: %w", err)
 	}
 	for _, update := range updates.Updates {
-		if err := u.updater.ApplyUpdate(ctx, update); err != nil {
+		if err := u.Updater.ApplyUpdate(ctx, update); err != nil {
 			return fmt.Errorf("applying update: %w", err)
 		}
 	}
@@ -118,7 +118,7 @@ func (u *RepoUpdater) updateBranch(ctx context.Context, log logrus.FieldLogger, 
 	}
 
 	// List dependencies while on this branch:
-	deps, err := u.updater.Dependencies(ctx)
+	deps, err := u.Updater.Dependencies(ctx)
 	if err != nil {
 		return fmt.Errorf("getting dependencies: %w", err)
 	}
@@ -184,7 +184,7 @@ func (u *RepoUpdater) updateBranch(ctx context.Context, log logrus.FieldLogger, 
 }
 
 func (u *RepoUpdater) checkForUpdate(ctx context.Context, log logrus.FieldLogger, dep Dependency, filter func(string) bool) *Update {
-	update, err := u.updater.Check(ctx, dep, filter)
+	update, err := u.Updater.Check(ctx, dep, filter)
 	if err != nil {
 		log.WithError(err).Warn("error checking for updates")
 		return nil
@@ -210,7 +210,7 @@ func (u *RepoUpdater) singleUpdate(ctx context.Context, log logrus.FieldLogger, 
 	if err := u.repo.NewBranch(baseBranch, branch); err != nil {
 		return false, fmt.Errorf("switching to target branch: %w", err)
 	}
-	if err := u.updater.ApplyUpdate(ctx, *update); err != nil {
+	if err := u.Updater.ApplyUpdate(ctx, *update); err != nil {
 		return false, fmt.Errorf("applying batched update: %w", err)
 	}
 
@@ -255,7 +255,7 @@ func (u *RepoUpdater) groupedUpdate(ctx context.Context, log logrus.FieldLogger,
 	}
 
 	for _, update := range updates {
-		if err := u.updater.ApplyUpdate(ctx, update); err != nil {
+		if err := u.Updater.ApplyUpdate(ctx, update); err != nil {
 			return 0, fmt.Errorf("applying batched update: %w", err)
 		}
 	}

--- a/updater/updater.go
+++ b/updater/updater.go
@@ -39,6 +39,7 @@ type Repo interface {
 }
 
 type Updater interface {
+	Name() string
 	Dependencies(context.Context) ([]Dependency, error)
 	Check(ctx context.Context, dep Dependency, filter func(string) bool) (*Update, error)
 	ApplyUpdate(context.Context, Update) error


### PR DESCRIPTION
Amends the `Updater` interface to include a `Name()` attribute, which is included in `repository_dispatch` events and used for filtration.

This allows `action-update-go` to only respond to dispatches affecting go modules.

Closes https://github.com/thepwagner/action-update/issues/33 