### PR TITLE
Update golangci/golangci-lint from v1.35.0-alpine to v1.35.2-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.35.0-alpine
+FROM golangci/golangci-lint:v1.35.2-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.35.2-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golangci/golangci-lint","previous":"v1.35.0-alpine","next":"v1.35.2-alpine"}]},"signature":"esclfa8tOgh/3YfC5ROZeEhiRGt63J6Z/Vt64yFxOXh1Cqhp17OxnIY2OyrjFCvF9/evruugJqlhj5PMD0D8Kg=="}
-->