### PR TITLE
Update golangci/golangci-lint from v1.35.2-alpine to v1.36.0-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.35.2-alpine
+FROM golangci/golangci-lint:v1.36.0-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.36.0-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golangci/golangci-lint","previous":"v1.35.2-alpine","next":"v1.36.0-alpine"}]},"signature":"PpUawunAu5ZG85Zsui7Cc+vOoCq97lQs0AJ8fT1KPRJ/faTHvi60X/H6fEIb+K84aRXgmgeBtQgq8fD+szhxqw=="}
-->