### PR TITLE
Update golang from 1.15.8 to 1.16.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,6 @@ jobs:
           ${{ runner.os }}-go-
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.15.8'
+        go-version: '1.16.0'
     - run: script/test
     - run: script/lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: '1.16.0'
       - uses: thepwagner/action-update-go@main
         with:
           log_level: debug

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -21,7 +21,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.15.8'
+          go-version: '1.16.0'
       - uses: thepwagner/action-update-go@main
         with:
           log_level: debug

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.8
+FROM golang:1.16.0
 
 # No executable, this tracks the version that should be used for CI
 


### PR DESCRIPTION
Here is golang 1.16.0, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golang","previous":"1.15.8","next":"1.16.0"}]},"signature":"tioZd5/YVLxz+HgEdijvtbn1Hf/G6SqtnyiMDQ35JE3zG8rD395v1ZoQLBZeQwe/7KrrAQRzyiKV3zGmoLKOIQ=="}
-->