### PR TITLE
Update golangci/golangci-lint from v1.37.0-alpine to v1.37.1-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.37.0-alpine
+FROM golangci/golangci-lint:v1.37.1-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.37.1-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golangci/golangci-lint","previous":"v1.37.0-alpine","next":"v1.37.1-alpine"}]},"signature":"dRuqsFK0v1Ds3yxtWHOjWAmXsiJuCUK9qs7r8/sFzkOo0AxnF8V2FnCypjdXirN0EnnINldI3ZnrJry/lr4sZA=="}
-->