### PR TITLE
Update github.com/google/go-github/v34 from v34.0.0 to v35.0.0

### DIFF
--- a/actions/env.go
+++ b/actions/env.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/actions/env_test.go
+++ b/actions/env_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/actions/handlers.go
+++ b/actions/handlers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	parser "github.com/caarlos0/env/v6"
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/actions/handlers_test.go
+++ b/actions/handlers_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thepwagner/action-update/actions"

--- a/actions/updateaction/issuecomment.go
+++ b/actions/updateaction/issuecomment.go
@@ -3,7 +3,7 @@ package updateaction
 import (
 	"context"
 
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/actions/updateaction/pullrequest.go
+++ b/actions/updateaction/pullrequest.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/repo"
 	"github.com/thepwagner/action-update/updater"

--- a/actions/updateaction/pullrequest_test.go
+++ b/actions/updateaction/pullrequest_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/thepwagner/action-update/actions/updateaction"
 )

--- a/actions/updateaction/release.go
+++ b/actions/updateaction/release.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/repo"
 )

--- a/actions/updateaction/release_test.go
+++ b/actions/updateaction/release_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/stretchr/testify/require"
 	"github.com/thepwagner/action-update/actions/updateaction"
 )

--- a/actions/updateaction/repositorydispatch.go
+++ b/actions/updateaction/repositorydispatch.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/repo"
 	"github.com/thepwagner/action-update/updater"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/bmatcuk/doublestar/v3 v3.0.0
 	github.com/caarlos0/env/v6 v6.5.0
 	github.com/go-git/go-git/v5 v5.3.0
-	github.com/google/go-github/v34 v34.0.0
+	github.com/google/go-github/v35 v35.0.0
 	github.com/otiai10/copy v1.5.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-github/v34 v34.0.0 h1:/siYFImY8KwGc5QD1gaPf+f8QX6tLwxNIco2RkYxoFA=
-github.com/google/go-github/v34 v34.0.0/go.mod h1:w/2qlrXUfty+lbyO6tatnzIw97v1CM+/jZcwXMDiPQQ=
+github.com/google/go-github/v35 v35.0.0 h1:oLrHdYkSQvbhN4gJihpEkTFKAZnIFgTCj1p/OlE4Os4=
+github.com/google/go-github/v35 v35.0.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=

--- a/repo/github.go
+++ b/repo/github.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/updater"
 	"golang.org/x/oauth2"

--- a/repo/pullrequest.go
+++ b/repo/pullrequest.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v34/github"
+	"github.com/google/go-github/v35/github"
 	"github.com/thepwagner/action-update/updater"
 )
 


### PR DESCRIPTION
Here is github.com/google/go-github/v34 v35.0.0, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/google/go-github/v34","previous":"v34.0.0","next":"v35.0.0"}]},"signature":"98SbUcILHASxQ2EnFzsOpSgvYv31eRyf0/P1GCh95RZHNcR7jR+QYd0e8VcXINtusR3MRe0UkvaRwnivku4IPQ=="}
-->