### PR TITLE
Update github.com/google/go-github/v35 from v35.0.0 to v35.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/bmatcuk/doublestar/v3 v3.0.0
 	github.com/caarlos0/env/v6 v6.5.0
 	github.com/go-git/go-git/v5 v5.3.0
-	github.com/google/go-github/v35 v35.0.0
+	github.com/google/go-github/v35 v35.1.0
 	github.com/otiai10/copy v1.5.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-github/v35 v35.0.0 h1:oLrHdYkSQvbhN4gJihpEkTFKAZnIFgTCj1p/OlE4Os4=
-github.com/google/go-github/v35 v35.0.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
+github.com/google/go-github/v35 v35.1.0 h1:KkwZnKWQ/0YryvXjZlCN/3EGRJNp6VCZPKo+RG9mG28=
+github.com/google/go-github/v35 v35.1.0/go.mod h1:s0515YVTI+IMrDoy9Y4pHt9ShGpzHvHO8rZ7L7acgvs=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=


### PR DESCRIPTION
Here is github.com/google/go-github/v35 v35.1.0, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/google/go-github/v35","previous":"v35.0.0","next":"v35.1.0"}]},"signature":"CWeugoaKZnkKazcKWi2PuZJIm382G2DBqS3Yqest3m+Y/6QxeNhj0rLi2iCnxDRhQpmCwi9iAotc05C6FLBk6w=="}
-->