### PR TITLE
Update golangci/golangci-lint from v1.40.0-alpine to v1.40.1-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.40.0-alpine
+FROM golangci/golangci-lint:v1.40.1-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.40.1-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golangci/golangci-lint","previous":"v1.40.0-alpine","next":"v1.40.1-alpine"}]},"signature":"exzhPqMwcRaKO4WTY9SRUYKpy1pcMsA6oJKeRHSpGG+UkFcCe6yeIAPLo0/smObrwOOM/TwmLI8iTH3ejarJpQ=="}
-->