### PR TITLE
Update golangci/golangci-lint from v1.41.0-alpine to v1.41.1-alpine

### DIFF
--- a/script/tools/golangci-lint/Dockerfile
+++ b/script/tools/golangci-lint/Dockerfile
@@ -1,3 +1,3 @@
-FROM golangci/golangci-lint:v1.41.0-alpine
+FROM golangci/golangci-lint:v1.41.1-alpine
 
 ENTRYPOINT ["/usr/bin/golangci-lint", "run", "--deadline=15m"]


### PR DESCRIPTION
Here is golangci/golangci-lint v1.41.1-alpine, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"golangci/golangci-lint","previous":"v1.41.0-alpine","next":"v1.41.1-alpine"}]},"signature":"PChCDFX0Hw0za4SywofpFkIs1bxONKjxK2+HlX8mmb4TyhUPBQ4fIhgQ3jJ4ufQ2sNLJ7okoGlmQ1q1JeYlJ9w=="}
-->