### PR TITLE
semver helpers

### DIFF
--- a/version/semver.go
+++ b/version/semver.go
@@ -1,0 +1,52 @@
+package version
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// Semverish coerces semver-ish strings to semver, or returns the empty string
+func Semverish(s string) string {
+	if v := isValidWithV(s); v != "" {
+		return v
+	}
+
+	dots := strings.Split(s, ".")
+	if len(dots) > 3 {
+		normal := strings.Join(dots[:3], ".") + "-" + strings.Join(dots[3:], ".")
+		if v := isValidWithV(normal); v != "" {
+			return v
+		}
+	}
+
+	return ""
+}
+
+func isValidWithV(s string) string {
+	if semver.IsValid(s) {
+		return s
+	}
+
+	if vt := fmt.Sprintf("v%s", s); semver.IsValid(vt) {
+		return vt
+	}
+	return ""
+}
+
+// SemverSort is an descending sort of semver-ish version strings. The latest version is at index 0.
+func SemverSort(versions []string) []string {
+	sort.Slice(versions, func(i, j int) bool {
+		// Prefer strict semver ordering:
+		if c := semver.Compare(Semverish(versions[i]), Semverish(versions[j])); c > 0 {
+			return true
+		} else if c < 0 {
+			return false
+		}
+		// Failing that, prefer the most specific version:
+		return strings.Count(versions[i], ".") > strings.Count(versions[j], ".")
+	})
+	return versions
+}

--- a/version/semver_test.go
+++ b/version/semver_test.go
@@ -1,0 +1,51 @@
+package version_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thepwagner/action-update/version"
+)
+
+func TestSemverish(t *testing.T) {
+	tests := map[string]string{
+		"v1":         "v1",
+		"1":          "v1",
+		"1.0":        "v1.0",
+		"1.0.0":      "v1.0.0",
+		"1.0.0.0":    "v1.0.0-0",
+		"1.0.0-beta": "v1.0.0-beta",
+		"1.0.0.beta": "v1.0.0-beta",
+	}
+	for in, expected := range tests {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, expected, version.Semverish(in))
+		})
+	}
+}
+
+func TestSemverSort(t *testing.T) {
+	tests := map[string]struct {
+		in       []string
+		expected []string
+	}{
+		"semver": {
+			in:       []string{"v3", "v1", "v2"},
+			expected: []string{"v3", "v2", "v1"},
+		},
+		"by specificity": {
+			in:       []string{"v1.0", "v1", "v1.0.0"},
+			expected: []string{"v1.0.0", "v1.0", "v1"},
+		},
+		"semver-ish": {
+			in:       []string{"3.0.3", "1.0.1", "2.0.2"},
+			expected: []string{"3.0.3", "2.0.2", "1.0.1"},
+		},
+	}
+
+	for lbl, tc := range tests {
+		t.Run(lbl, func(t *testing.T) {
+			assert.Equal(t, tc.expected, version.SemverSort(tc.in))
+		})
+	}
+}


### PR DESCRIPTION
Promote some helpers from [action-update-docker](https://github.com/thepwagner/action-update-docker/blob/b149d63677ea19eb6c036464ef4417fbf59362c7/docker/check.go#L74-L97), because I'd like to use them in `action-update-docker-url`.

In particular, I noticed https://github.com/tianon/gosu/releases isn't being updated - these test support it.