### PR TITLE
Update github.com/google/go-github/v36 from v36.0.0 to v37.0.0

### DIFF
--- a/actions/env.go
+++ b/actions/env.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/actions/env_test.go
+++ b/actions/env_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/actions/handlers.go
+++ b/actions/handlers.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	parser "github.com/caarlos0/env/v6"
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/actions/handlers_test.go
+++ b/actions/handlers_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thepwagner/action-update/actions"

--- a/actions/updateaction/issuecomment.go
+++ b/actions/updateaction/issuecomment.go
@@ -3,7 +3,7 @@ package updateaction
 import (
 	"context"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/actions/updateaction/pullrequest.go
+++ b/actions/updateaction/pullrequest.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/repo"
 	"github.com/thepwagner/action-update/updater"

--- a/actions/updateaction/pullrequest_test.go
+++ b/actions/updateaction/pullrequest_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/thepwagner/action-update/actions/updateaction"
 )

--- a/actions/updateaction/release.go
+++ b/actions/updateaction/release.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/repo"
 )

--- a/actions/updateaction/release_test.go
+++ b/actions/updateaction/release_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/stretchr/testify/require"
 	"github.com/thepwagner/action-update/actions/updateaction"
 )

--- a/actions/updateaction/repositorydispatch.go
+++ b/actions/updateaction/repositorydispatch.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/repo"
 	"github.com/thepwagner/action-update/updater"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.0.2
 	github.com/caarlos0/env/v6 v6.6.2
 	github.com/go-git/go-git/v5 v5.4.2
-	github.com/google/go-github/v36 v36.0.0
+	github.com/google/go-github/v37 v37.0.0
 	github.com/otiai10/copy v1.6.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-github/v36 v36.0.0 h1:ndCzM616/oijwufI7nBRa+5eZHLldT+4yIB68ib5ogs=
-github.com/google/go-github/v36 v36.0.0/go.mod h1:LFlKC047IOqiglRGNqNb9s/iAPTnnjtlshm+bxp+kwk=
+github.com/google/go-github/v37 v37.0.0 h1:rCspN8/6kB1BAJWZfuafvHhyfIo5fkAulaP/3bOQ/tM=
+github.com/google/go-github/v37 v37.0.0/go.mod h1:LM7in3NmXDrX58GbEHy7FtNLbI2JijX93RnMKvWG3m4=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=

--- a/repo/github.go
+++ b/repo/github.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/sirupsen/logrus"
 	"github.com/thepwagner/action-update/updater"
 	"golang.org/x/oauth2"

--- a/repo/pullrequest.go
+++ b/repo/pullrequest.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/go-github/v36/github"
+	"github.com/google/go-github/v37/github"
 	"github.com/thepwagner/action-update/updater"
 )
 


### PR DESCRIPTION
Here is github.com/google/go-github/v36 v37.0.0, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/google/go-github/v36","previous":"v36.0.0","next":"v37.0.0"}]},"signature":"mVHsHmFe7XkVcWRZWmHUsz8khXxAM6WapjWjuP4hBMK/DZEiFiTrK15I9gVE0TbdZOZpxfFR+91uYGUiK/TJeg=="}
-->